### PR TITLE
`RobotsTxtParser` does not work on Windows server

### DIFF
--- a/includes/robotstxtparser.php
+++ b/includes/robotstxtparser.php
@@ -94,12 +94,14 @@ class RobotsTxtParser
         $encoding = !empty($encoding) ? $encoding : mb_detect_encoding($content);
         mb_internal_encoding($encoding);
 
+        $content = preg_replace( '/\R/', "\n", $content );
+
         // set content
         $this->content = iconv($encoding, 'UTF-8//IGNORE', $content);
 
         // Ensure that there's a newline at the end of the file, otherwise the
         // last line is ignored
-        $this->content .= PHP_EOL;
+        $this->content .= "\n";
 
         // set default state
         $this->state = self::STATE_ZERO_POINT;
@@ -224,7 +226,7 @@ class RobotsTxtParser
     protected function newLine()
     {
         return in_array(
-            PHP_EOL, array(
+            "\n", array(
                 $this->current_char,
                 $this->current_word
             )


### PR DESCRIPTION
The parser uses `PHP_EOL` als a line delimiter, which on Windows is "\r\n" (two characters!).

The `newLine()` method tests for a newline on either the current char (one character so the "\r" on Windows) or on the current word. Since the current word contains all text before the newline (eg. "*\r\n") it is never triggered, resulting in an empty rules array.

This change forces the use of "\n" as a newline character in stead of PHP_EOL.